### PR TITLE
Update the appmetrics dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     }
   },
   "dependencies": {
-    "appmetrics-dash": "^4.1.0",
-    "appmetrics-prometheus": "^2.0.0",
+    "appmetrics-dash": "^5.0.0",
+    "appmetrics-prometheus": "^3.0.0",
     "appmetrics-zipkin": "^1.1.1",
     "body-parser": "^1.18.3",
     "express": "^4.16.4",


### PR DESCRIPTION
Move appmetrics-dash to 5.0.0 and appmetrics-prometheus to 3.0.0 to pick up fixes in appmetrics.